### PR TITLE
using mtune=generic instead of -march=native on Linux

### DIFF
--- a/recipe/0001-cmake-mtune-fix.patch
+++ b/recipe/0001-cmake-mtune-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0221d6a..c5421ae 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -126,10 +126,7 @@ endif()
+ 
+ # -march=native for GCC, Clang and ICC in any version that does support it.
+ if ((NOT CRYPTOPP_CROSS_COMPILE) AND (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU|Intel"))
+-	CHECK_CXX_COMPILER_FLAG("-march=native" COMPILER_OPT_ARCH_NATIVE_SUPPORTED)
+-	if (COMPILER_OPT_ARCH_NATIVE_SUPPORTED AND NOT CMAKE_CXX_FLAGS MATCHES "-march=")
+-		SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+-	endif()
++        SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mtune=generic")
+ endif()
+ 
+ # Solaris specific 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,6 +1,6 @@
 mkdir build
 cd build
-cmake -G "NMake Makefiles" -D BUILD_SHARED=OFF -D BUILD_TESTING=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ..
+cmake -G "NMake Makefiles" -D DISABLE_SSSE3=ON -D BUILD_SHARED=OFF -D BUILD_TESTING=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ..
 if errorlevel 1 exit 1
 nmake
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
+# cryptopp files are stored with CRLF eol, making impossible to patch them the conda way
+# can be remover in the enxt release of cryptopp since its cmakelists will have an option
+# to remove march=generic flag
+#sed -i s/$/$'\r'/ $RECIPE_DIR/0001-cmake-mtune-fix.patch
+#git apply --binary $RECIPE_DIR/0001-cmake-mtune-fix.patch
 mkdir build
 cd build
-cmake -D BUILD_SHARED=OFF -D BUILD_TESTING=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_LIBDIR=lib -D CMAKE_INSTALL_PREFIX=$PREFIX ..
+cmake -D BUILD_SHARED=OFF -D DISABLE_SSSE3=ON -D BUILD_TESTING=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_LIBDIR=lib -D CMAKE_INSTALL_PREFIX=$PREFIX ..
 make
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,13 @@ source:
   url: https://github.com/weidai11/cryptopp/archive/{{ name | upper }}_{{ version | replace('.', '_') }}.tar.gz
   sha256: {{ sha256 }}
 
+  patches:
+    # Replaces flag -march=native with flag  -mtune=generic
+    # This flag can be removed via cmake optino in the next release
+    - 0001-cmake-mtune-fix.patch  # [not win]
+
 build:
-  number: 1
+  number: 3
   skip: true  # [win and py27]
   features:
     - vc9     # [win and py27]


### PR DESCRIPTION
This option prevents to distribute the packages on machines which processor is older than the one used to build the binary. Indeed, the build can generate illegal instructions for older processors.