### PR TITLE
Fix ppc64le

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -65,7 +65,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 
 
@@ -77,7 +77,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/.scripts/run_win_build.bat
+++ b/.scripts/run_win_build.bat
@@ -24,7 +24,7 @@ set "CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1"
 
 :: Provision the necessary dependencies to build the recipe later
 echo Installing dependencies
-mamba.exe install "python=3.10" pip mamba conda-build boa conda-forge-ci-setup=4 -c conda-forge --strict-channel-priority --yes
+mamba.exe install "python=3.10" pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1" -c conda-forge --strict-channel-priority --yes
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Set basic configuration
@@ -50,7 +50,7 @@ call :end_group
 
 :: Build the recipe
 echo Building recipe
-conda.exe mambabuild "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
+conda.exe build "recipe" -m .ci_support\%CONFIG%.yaml --suppress-variables %EXTRA_CB_OPTIONS%
 if !errorlevel! neq 0 exit /b !errorlevel!
 
 :: Prepare some environment variables for the upload step

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/recipe/113.patch
+++ b/recipe/113.patch
@@ -1,0 +1,23 @@
+From fb46689a1161e936fa88ecd7a06d5136327666a8 Mon Sep 17 00:00:00 2001
+From: Chris Burr <christopher.burr@cern.ch>
+Date: Sun, 10 Mar 2024 12:05:57 +0100
+Subject: [PATCH] Add missing ppc sources
+
+---
+ cryptopp/sources.cmake | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/cryptopp/sources.cmake b/cryptopp/sources.cmake
+index 34de12f..7c1b8a0 100644
+--- a/cryptopp/sources.cmake
++++ b/cryptopp/sources.cmake
+@@ -115,6 +115,9 @@ set(cryptopp_SOURCES
+     pkcspad.cpp
+     poly1305.cpp
+     polynomi.cpp
++    power7_ppc.cpp
++    power8_ppc.cpp
++    power9_ppc.cpp
+     ppc_simd.cpp
+     primetab.cpp
+     pssr.cpp

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
       - 113.patch
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
     fn: cmake-{{ name | upper }}-{{ version | replace('.', '_') }}.tar.gz
     url: https://github.com/abdes/cryptopp-cmake/archive/{{ name | upper }}_{{ version | replace('.', '_') }}.tar.gz
     sha256: {{ sha256_cmake }}
+    patches:
+      - 113.patch
 
 build:
   number: 0


### PR DESCRIPTION
https://github.com/conda-forge/python-gfal2-feedstock/pull/37 is failing with:

```
error: symbol lookup error: undefined symbol: _ZN8CryptoPP15CPU_ProbePower8Ev (fatal)
```

The underlying cause is because some of the power sources are missed in `cryptopp-cmake`, see https://github.com/abdes/cryptopp-cmake/pull/113